### PR TITLE
Remove stub store.init to be compatible with Octane.

### DIFF
--- a/addon-test-support/stub.js
+++ b/addon-test-support/stub.js
@@ -36,7 +36,6 @@ export const storeMethods = [
   'flushPendingSave',
   'getReference',
   'hashRecordForId',
-  'init',
   'modelFor',
   'normalize',
   'peekAll',


### PR DESCRIPTION
#PATCH#

Remove stub store.init to be compatible with Ember Octane. We can't override init without calling `this._super(...)`

# CHANGELOG
Remove stub store.init to be compatible with Ember Octane
